### PR TITLE
feat: add grid lines and minor ticks

### DIFF
--- a/scripts/omicron_plot.py
+++ b/scripts/omicron_plot.py
@@ -75,6 +75,10 @@ def plot_omicron_share(df,reason,scale):
     formatter = mdates.ConciseDateFormatter(locator)
     ax.xaxis.set_major_locator(locator)
     ax.xaxis.set_major_formatter(formatter)
+    ax.xaxis.set_minor_locator(ticker.MultipleLocator(base=1.0))
+    ax.grid(True, which='major', linewidth=0.25)
+    ax.grid(True, which='minor', linewidth=0.1)
+    ax.set_axisbelow(True)
 
     if scale == 'logit':
         ax.yaxis.set_major_formatter(ticker.FuncFormatter(lambda y, _: f'{float(f"{100*y:.1g}"):g}%'))


### PR DESCRIPTION
Although I know that this data is only a rough approximation of the actual infections, I found myself looking really close at the graphs to see which day a data point belongs to, or where along the Y-axis it might be.

This PR enables a major and minor grid, and minor ticks along the X-axis.

Here's an example of the results:

![omicron_N_linear](https://user-images.githubusercontent.com/1325019/147476747-db79aef5-55a2-46a1-b28d-a9611c049d8a.png)
![omicron_N_logit](https://user-images.githubusercontent.com/1325019/147476759-481d2379-3fea-40d7-8abc-52199680f946.png)
